### PR TITLE
Fix makefile copy statement

### DIFF
--- a/digital/lab1/Makefile
+++ b/digital/lab1/Makefile
@@ -7,7 +7,7 @@ full_adder: src/full_adder.sv tb/tb_full_adder.sv
 
 eight_bit_adder: src/full_adder.sv src/eight_bit_adder.sv tb/tb_eight_bit_adder.sv
 	$(VERILATE) $(VERILATE_FLAGS) --top-module tb_eight_bit_adder $^
-	cp obj_dir/Veight_bit_adder .
+	cp obj_dir/Vtb_eight_bit_adder .
 
 counter: src/counter.sv tb/tb_counter.sv
 	$(VERILATE) $(VERILATE_FLAGS) $^


### PR DESCRIPTION
Created file is named Vtb_eight_bit_adder while the cp command tries to copy Veight_bit_adder